### PR TITLE
fix: package-lock.json has wrong name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "discord-oidc",
+  "name": "discord-oidc-worker",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "discord-oidc",
+      "name": "discord-oidc-worker",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Missing -worker suffix